### PR TITLE
Set bucket name through env var

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -47,7 +47,7 @@ config :starknet_explorer, rpc_host: rpc_host
 
 config :starknet_explorer,
   rpc_host: rpc_host,
-  s3_bucket_name: "kraken-proofs",
+  s3_bucket_name: System.get_env("S3_BUCKET_NAME"),
   prover_storage: System.get_env("PROVER_STORAGE"),
   proofs_root_dir: System.get_env("PROOFS_ROOT_DIR") || "./proofs"
 


### PR DESCRIPTION
Currently the bucket name is hardcoded, but we want the user to decide the name of their own buckets in which to store and from which to retrieve the proofs.