### PR TITLE
Add release file and set cache logging to debug.

### DIFF
--- a/lib/cache_request_warmer.ex
+++ b/lib/cache_request_warmer.ex
@@ -2,7 +2,7 @@ defmodule StarknetExplorer.Cache.BlockWarmer do
   require Logger
   use Cachex.Warmer
   alias StarknetExplorer.Rpc
-  @interval :timer.seconds(5)
+  @interval :timer.seconds(60)
   def interval, do: @interval
 
   def execute(%{network: network})

--- a/lib/cache_request_warmer.ex
+++ b/lib/cache_request_warmer.ex
@@ -2,12 +2,12 @@ defmodule StarknetExplorer.Cache.BlockWarmer do
   require Logger
   use Cachex.Warmer
   alias StarknetExplorer.Rpc
-  @interval :timer.seconds(60)
+  @interval :timer.seconds(10)
   def interval, do: @interval
 
   def execute(%{network: network})
       when network in [:mainnet, :testnet, :testnet2] do
-    Logger.info("Warming cache for #{network}")
+    Logger.debug("Warming cache for #{network}")
     # Try/Rescue is not really an elixir/erlang thing to do, but
     # I think this is the most simple way to do this, since
     # this process can crash the whole application on startup.

--- a/lib/starknet_explorer/release.ex
+++ b/lib/starknet_explorer/release.ex
@@ -1,0 +1,28 @@
+defmodule StarknetExplorer.Release do
+  @moduledoc """
+  Used for executing DB release tasks when run in production without Mix
+  installed.
+  """
+  @app :starknet_explorer
+
+  def migrate do
+    load_app()
+
+    for repo <- repos() do
+      {:ok, _, _} = Ecto.Migrator.with_repo(repo, &Ecto.Migrator.run(&1, :up, all: true))
+    end
+  end
+
+  def rollback(repo, version) do
+    load_app()
+    {:ok, _, _} = Ecto.Migrator.with_repo(repo, &Ecto.Migrator.run(&1, :down, to: version))
+  end
+
+  defp repos do
+    Application.fetch_env!(@app, :ecto_repos)
+  end
+
+  defp load_app do
+    Application.load(@app)
+  end
+end


### PR DESCRIPTION
## Changes:
- The Phoenix Release file was not generated so we had to run migrations manually on release, 
   this will add the migrate command to the release to make it easier.
- Lowered the cache log to debug level because It only adds noise when trying to debug on a deploy.