### PR TITLE
stop topbar after loading

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -306,10 +306,23 @@ Hooks.Dropdown = {
 let csrfToken = document.querySelector("meta[name='csrf-token']").getAttribute("content");
 let liveSocket = new LiveSocket("/live", Socket, { params: { _csrf_token: csrfToken }, hooks: Hooks });
 
-// Show progress bar on live navigation and form submits
-topbar.config({ barColors: { 0: "#29d" }, shadowColor: "rgba(0, 0, 0, .3)" });
-window.addEventListener("phx:page-loading-start", (_info) => topbar.show(300));
-window.addEventListener("phx:page-loading-stop", (_info) => topbar.hide());
+// Show progress bar on live navigation and form submits. Only displays if still
+// loading after 300 msec
+topbar.config({barColors: {0: "#29d"}, shadowColor: "rgba(0, 0, 0, .3)"})
+
+let topBarScheduled = undefined;
+window.addEventListener("phx:page-loading-start", () => {
+  if(!topBarScheduled) {
+    topBarScheduled = setTimeout(() => topbar.show(), 300);
+  };
+});
+window.addEventListener("phx:page-loading-stop", () => {
+  clearTimeout(topBarScheduled);
+  topBarScheduled = undefined;
+  topbar.hide();
+});
+
+
 // connect if there are any LiveViews on the page
 liveSocket.connect();
 


### PR DESCRIPTION
`topbar` kept showing after the page was fully loaded.

I applied what is shown in this article: 
https://fly.io/phoenix-files/make-your-liveview-feel-faster/