### PR TITLE
Add L1->L2 messages and various refactors

### DIFF
--- a/lib/starknet_explorer/block/block.ex
+++ b/lib/starknet_explorer/block/block.ex
@@ -71,22 +71,23 @@ defmodule StarknetExplorer.Block do
 
         _txs_changeset =
           Enum.map(txs, fn tx ->
-            tx =
+            inserted_tx =
               Ecto.build_assoc(block, :transactions, tx)
               |> Transaction.changeset(tx)
               |> Repo.insert!()
 
-            receipt = receipts[tx.hash]
+            receipt = receipts[inserted_tx.hash]
 
             receipt =
               receipt
               |> Map.put("timestamp", block.timestamp)
 
-            Ecto.build_assoc(tx, :receipt, receipt)
+            Ecto.build_assoc(inserted_tx, :receipt, receipt)
             |> Receipt.changeset(receipt)
             |> Repo.insert!()
 
             Message.insert_from_transaction_receipt(receipt, network)
+            Message.insert_from_transaction(inserted_tx, block.timestamp, network)
           end)
       end)
 

--- a/lib/starknet_explorer/block/block_utils.ex
+++ b/lib/starknet_explorer/block/block_utils.ex
@@ -33,13 +33,6 @@ defmodule StarknetExplorer.BlockUtils do
   end
 
   defp receipts_for_block(_block = %{"transactions" => transactions}, network) do
-    # receipts =
-    # transactions
-    # |> Map.new(fn %{"transaction_hash" => tx_hash} ->
-    # {:ok, receipt} = Rpc.get_transaction_receipt(tx_hash, :mainnet)
-    # {tx_hash, receipt}
-    # end)
-
     receipts =
       transactions
       |> Enum.chunk_every(75)

--- a/lib/starknet_explorer/message.ex
+++ b/lib/starknet_explorer/message.ex
@@ -75,10 +75,7 @@ defmodule StarknetExplorer.Message do
   def insert_from_transaction(transaction, timestamp, network) do
     message =
       transaction
-      # |> StarknetExplorerWeb.Utils.atomize_keys()
       |> from_transaction()
-
-    IO.inspect(message)
 
     case message do
       nil ->

--- a/lib/starknet_explorer/message.ex
+++ b/lib/starknet_explorer/message.ex
@@ -1,6 +1,7 @@
 defmodule StarknetExplorer.Message do
   use Ecto.Schema
   import Ecto.Changeset
+  import Ecto.Query
   alias StarknetExplorer.Repo
 
   @primary_key {:message_hash, :string, autogenerate: false}
@@ -21,7 +22,19 @@ defmodule StarknetExplorer.Message do
     field :to_address, :string
     field :payload, {:array, :string}
     field :timestamp, :integer
-    field :type, :string
+
+    field :type, Ecto.Enum,
+      values: [
+        :l2_to_l1_executed_on_l2,
+        :l2_to_l1_logged_on_l1,
+        :l2_to_l1_consumed_on_l1,
+        :l1_to_l2_logged_on_l1,
+        :l1_to_l2_executed_on_l2,
+        :l1_to_l2_consumed_on_l1,
+        :l1_to_l2_cancellation_started_on_l1,
+        :l1_to_l2_cancelled_on_l1
+      ]
+
     field :network, Ecto.Enum, values: [:mainnet, :testnet, :testnet2]
     # belongs_to :transaction, Transaction, foreign_key: :transaction_hash, references: :hash
     timestamps()
@@ -50,6 +63,37 @@ defmodule StarknetExplorer.Message do
     end)
   end
 
+  def latest_n_messages(n \\ 20) do
+    query =
+      from msg in StarknetExplorer.Message,
+        order_by: [desc: msg.timestamp],
+        limit: ^n
+
+    Repo.all(query)
+  end
+
+  def insert_from_transaction(transaction, timestamp, network) do
+    message =
+      transaction
+      # |> StarknetExplorerWeb.Utils.atomize_keys()
+      |> from_transaction()
+
+    IO.inspect(message)
+
+    case message do
+      nil ->
+        :skip
+
+      message ->
+        changeset(
+          %StarknetExplorer.Message{},
+          message |> Map.put(:timestamp, timestamp) |> Map.put(:network, network)
+        )
+        |> Repo.insert!(returning: false)
+    end
+  end
+
+  @spec from_transaction_receipt(atom | %{:messages_sent => any, optional(any) => any}) :: list
   def from_transaction_receipt(receipt) do
     Enum.map(receipt.messages_sent, fn message ->
       message = message |> StarknetExplorerWeb.Utils.atomize_keys()
@@ -69,10 +113,49 @@ defmodule StarknetExplorer.Message do
         from_address: message.from_address,
         to_address: message.to_address,
         payload: message.payload,
-        # TODO: this needs to be revisited once L1 messages are added and processed
-        type: "Sent on L2",
+        type: :l2_to_l1_executed_on_l2,
         message_hash: String.downcase("0x" <> keccak_message_hash)
       }
     end)
   end
+
+  # messages from L1 to L2 have to be derived from transactions
+  def from_transaction(transaction) do
+    case transaction.type do
+      "L1_HANDLER" ->
+        %{calldata: [from_address | payload] = transaction.calldata}
+
+        hash_input =
+          Abi.encode_packed_mixed([
+            from_address,
+            transaction.contract_address,
+            transaction.nonce,
+            transaction.entry_point_selector,
+            length(payload),
+            payload
+          ])
+
+        %{
+          transaction_hash: transaction.hash,
+          from_address: from_address,
+          to_address: transaction.contract_address,
+          payload: payload,
+          type: :l1_to_l2_executed_on_l2,
+          message_hash: String.downcase("0x" <> Base.encode16(ExKeccak.hash_256(hash_input)))
+        }
+
+      _ ->
+        nil
+    end
+  end
+
+  def friendly_message_type(:l2_to_l1_executed_on_l2), do: "Sent on L2"
+  def friendly_message_type(:l1_to_l2_executed_on_l2), do: "Consumed on L2"
+  # TODO: Add message type names
+  def friendly_message_type(_), do: "-"
+
+  def is_l2_to_l1(:l2_to_l1_executed_on_l2), do: true
+  def is_l2_to_l1(:l2_to_l1_logged_on_l1), do: true
+  def is_l2_to_l1(:l2_to_l1_consumed_on_l1), do: true
+  def is_l2_to_l1(_), do: false
 end

--- a/lib/starknet_explorer_web/live/message_index_live.ex
+++ b/lib/starknet_explorer_web/live/message_index_live.ex
@@ -1,6 +1,7 @@
 defmodule StarknetExplorerWeb.MessageIndexLive do
   use StarknetExplorerWeb, :live_view
   alias StarknetExplorerWeb.Utils
+  alias StarknetExplorer.Message
 
   @impl true
   def render(assigns) do
@@ -13,82 +14,143 @@ defmodule StarknetExplorerWeb.MessageIndexLive do
     <div class="max-w-7xl mx-auto">
       <div class="table-header !justify-start gap-5">
         <h2>Messages</h2>
-        <span class="gray-label text-sm">Mocked</span>
       </div>
       <div class="table-block">
-        <div class="grid-9 table-th">
-          <div>Identifier</div>
+        <div class="grid-6 table-th">
           <div>Message Hash</div>
           <div>Direction</div>
-          <div class="col-span-2">Type</div>
+          <div>Type</div>
           <div>From Address</div>
           <div>To Address</div>
           <div>Transaction Hash</div>
-          <div>Age</div>
         </div>
-        <%= for idx <- 0..30 do %>
-          <div id={"message-#{idx}"} class="grid-9 custom-list-item">
-            <div>
-              <div class="list-h">Identifier</div>
-              <%= live_redirect(
-                Utils.shorten_block_hash(
-                  "0x06e681a4da193cfd86e28a2879a17f4aedb4439d61a4a776b1e5686e9a4f96b2"
-                ),
-                to:
-                  ~p"/#{@network}/messages/0x06e681a4da193cfd86e28a2879a17f4aedb4439d61a4a776b1e5686e9a4f96b2",
-                class: "text-hover-blue"
-              ) %>
-            </div>
+        <%= for message <- @messages do %>
+          <div class="grid-6 custom-list-item">
             <div>
               <div class="list-h">Message Hash</div>
-              <%= live_redirect(
-                Utils.shorten_block_hash(
-                  "0xd8eda3e8962aa40cab490a11bd6e07e4f2a4b3fd276a6521c9fa2fc39165346b"
-                ),
-                to:
-                  ~p"/#{@network}/messages/0x06e681a4da193cfd86e28a2879a17f4aedb4439d61a4a776b1e5686e9a4f96b2"
-              ) %>
+              <div
+                class="flex gap-2 items-center copy-container"
+                id={"copy-transaction-hash-#{message.message_hash}"}
+                phx-hook="Copy"
+              >
+                <div class="relative">
+                  <div class="break-all text-hover-blue">
+                    <%= live_redirect(message.message_hash |> Utils.shorten_block_hash(),
+                      to: ~p"/#{@network}/messages/#{message.message_hash}"
+                    ) %>
+                  </div>
+                  <div class="absolute top-1/2 -right-6 tranform -translate-y-1/2">
+                    <div class="relative">
+                      <img
+                        class="copy-btn copy-text w-4 h-4"
+                        src={~p"/images/copy.svg"}
+                        data-text={message.message_hash}
+                      />
+                      <img
+                        class="copy-check absolute top-0 left-0 w-4 h-4 opacity-0 pointer-events-none"
+                        src={~p"/images/check-square.svg"}
+                      />
+                    </div>
+                  </div>
+                </div>
+              </div>
             </div>
             <div>
               <div class="list-h">Direction</div>
-              <div><span class="green-label">L2</span>-> <span class="blue-label">L1</span></div>
+              <%= if Message.is_l2_to_l1(message.type) do %>
+                <div><span class="green-label">L2</span>→<span class="blue-label">L1</span></div>
+              <% else %>
+                <div><span class="blue-label">L1</span>→<span class="green-label">L2</span></div>
+              <% end %>
             </div>
-            <div class="col-span-2">
+            <div>
               <div class="list-h">Type</div>
-              <div class="violet-label">CONSUMED_ON_L1</div>
+              <div>
+                <%= Message.friendly_message_type(message.type) %>
+              </div>
             </div>
             <div>
               <div class="list-h">From Address</div>
-              <%= live_redirect(
-                Utils.shorten_block_hash(
-                  "0x073314940630fd6dcda0d772d4c972c4e0a9946bef9dabf4ef84eda8ef542b82"
-                ),
-                to:
-                  ~p"/#{@network}/contracts/0x06e681a4da193cfd86e28a2879a17f4aedb4439d61a4a776b1e5686e9a4f96b2"
-              ) %>
+              <div
+                class="flex gap-2 items-center copy-container"
+                id={"copy-transaction-hash-#{message.from_address}"}
+                phx-hook="Copy"
+              >
+                <div class="relative">
+                  <div class="break-all">
+                    <%= Utils.shorten_block_hash(message.from_address) %>
+                  </div>
+                  <div class="absolute top-1/2 -right-6 tranform -translate-y-1/2">
+                    <div class="relative">
+                      <img
+                        class="copy-btn copy-text w-4 h-4"
+                        src={~p"/images/copy.svg"}
+                        data-text={message.from_address}
+                      />
+                      <img
+                        class="copy-check absolute top-0 left-0 w-4 h-4 opacity-0 pointer-events-none"
+                        src={~p"/images/check-square.svg"}
+                      />
+                    </div>
+                  </div>
+                </div>
+              </div>
             </div>
             <div>
               <div class="list-h">To Address</div>
-              <%= live_redirect(
-                Utils.shorten_block_hash("0xae0ee0a63a2ce6baeeffe56e7714fb4efe48d419"),
-                to:
-                  ~p"/#{@network}/etherscan_contracts/0x06e681a4da193cfd86e28a2879a17f4aedb4439d61a4a776b1e5686e9a4f96b2"
-              ) %>
+              <div
+                class="flex gap-2 items-center copy-container"
+                id={"copy-transaction-hash-#{message.to_address}"}
+                phx-hook="Copy"
+              >
+                <div class="relative">
+                  <div class="break-all">
+                    <%= Utils.shorten_block_hash(message.to_address) %>
+                  </div>
+                  <div class="absolute top-1/2 -right-6 tranform -translate-y-1/2">
+                    <div class="relative">
+                      <img
+                        class="copy-btn copy-text w-4 h-4"
+                        src={~p"/images/copy.svg"}
+                        data-text={message.to_address}
+                      />
+                      <img
+                        class="copy-check absolute top-0 left-0 w-4 h-4 opacity-0 pointer-events-none"
+                        src={~p"/images/check-square.svg"}
+                      />
+                    </div>
+                  </div>
+                </div>
+              </div>
             </div>
             <div>
               <div class="list-h">Transaction Hash</div>
-              <%= live_redirect(
-                Utils.shorten_block_hash(
-                  "0xaffd6222cce4c2f43286d01c4f4ab2c6ce73421f0233484557a011d1485499e1"
-                ),
-                to:
-                  ~p"/#{@network}/etherscan_transactions/0x06e681a4da193cfd86e28a2879a17f4aedb4439d61a4a776b1e5686e9a4f96b2",
-                class: "text-hover-blue"
-              ) %>
-            </div>
-            <div>
-              <div class="list-h">Age</div>
-              <div>5 min</div>
+              <div
+                class="flex gap-2 items-center copy-container"
+                id={"copy-transaction-hash-#{message.transaction_hash}"}
+                phx-hook="Copy"
+              >
+                <div class="relative">
+                  <div class="break-all text-hover-blue">
+                    <%= live_redirect(message.transaction_hash |> Utils.shorten_block_hash(),
+                      to: ~p"/#{@network}/transactions/#{message.transaction_hash}"
+                    ) %>
+                  </div>
+                  <div class="absolute top-1/2 -right-6 tranform -translate-y-1/2">
+                    <div class="relative">
+                      <img
+                        class="copy-btn copy-text w-4 h-4"
+                        src={~p"/images/copy.svg"}
+                        data-text={message.transaction_hash}
+                      />
+                      <img
+                        class="copy-check absolute top-0 left-0 w-4 h-4 opacity-0 pointer-events-none"
+                        src={~p"/images/check-square.svg"}
+                      />
+                    </div>
+                  </div>
+                </div>
+              </div>
             </div>
           </div>
         <% end %>
@@ -100,13 +162,14 @@ defmodule StarknetExplorerWeb.MessageIndexLive do
   @impl true
   def mount(_params, _session, socket) do
     Process.send(self(), :load_messages, [])
-
-    {:ok, assign(socket, messages: [])}
+    messages = Message.latest_n_messages(20)
+    {:ok, assign(socket, messages: messages)}
   end
 
   @impl true
   def handle_info(:load_messages, socket) do
     # TODO: Fetch this from the db
-    {:noreply, assign(socket, messages: [])}
+    messages = Message.latest_n_messages(20)
+    {:noreply, assign(socket, messages: messages)}
   end
 end

--- a/lib/starknet_explorer_web/live/transaction_live.ex
+++ b/lib/starknet_explorer_web/live/transaction_live.ex
@@ -175,7 +175,9 @@ defmodule StarknetExplorerWeb.TransactionLive do
             >
               <div class="relative">
                 <div class="break-all text-hover-blue">
-                  <%= Utils.shorten_block_hash(message.message_hash) %>
+                  <%= live_redirect(message.message_hash |> Utils.shorten_block_hash(),
+                    to: ~p"/#{@network}/messages/#{message.message_hash}"
+                  ) %>
                 </div>
                 <div class="absolute top-1/2 -right-6 tranform -translate-y-1/2">
                   <div class="relative">
@@ -195,11 +197,17 @@ defmodule StarknetExplorerWeb.TransactionLive do
           </div>
           <div>
             <div class="list-h">Direction</div>
-            <div><span class="green-label">L2</span>><span class="blue-label">L1</span></div>
+            <%= if Message.is_l2_to_l1(message.type) do %>
+              <div><span class="green-label">L2</span>→<span class="blue-label">L1</span></div>
+            <% else %>
+              <div><span class="blue-label">L1</span>→<span class="green-label">L2</span></div>
+            <% end %>
           </div>
           <div>
             <div class="list-h">Type</div>
-            <div>Sent On L2</div>
+            <div>
+              <%= Message.friendly_message_type(message.type) %>
+            </div>
           </div>
           <div>
             <div class="list-h">From Address</div>
@@ -209,7 +217,7 @@ defmodule StarknetExplorerWeb.TransactionLive do
               phx-hook="Copy"
             >
               <div class="relative">
-                <div class="break-all text-hover-blue">
+                <div class="break-all">
                   <%= Utils.shorten_block_hash(message.from_address) %>
                 </div>
                 <div class="absolute top-1/2 -right-6 tranform -translate-y-1/2">
@@ -236,7 +244,7 @@ defmodule StarknetExplorerWeb.TransactionLive do
               phx-hook="Copy"
             >
               <div class="relative">
-                <div class="break-all text-hover-blue">
+                <div class="break-all">
                   <%= Utils.shorten_block_hash(message.to_address) %>
                 </div>
                 <div class="absolute top-1/2 -right-6 tranform -translate-y-1/2">
@@ -264,7 +272,9 @@ defmodule StarknetExplorerWeb.TransactionLive do
             >
               <div class="relative">
                 <div class="break-all text-hover-blue">
-                  <%= Utils.shorten_block_hash(message.transaction_hash) %>
+                  <%= live_redirect(message.transaction_hash |> Utils.shorten_block_hash(),
+                    to: ~p"/#{@network}/transactions/#{message.transaction_hash}"
+                  ) %>
                 </div>
                 <div class="absolute top-1/2 -right-6 tranform -translate-y-1/2">
                   <div class="relative">
@@ -633,7 +643,10 @@ defmodule StarknetExplorerWeb.TransactionLive do
     {:ok, transaction = %{receipt: receipt}} =
       Data.transaction(transaction_hash, socket.assigns.network)
 
-    messages_sent = Message.from_transaction_receipt(receipt)
+    # a tx should not have both L1->L2 and L2->L1 messages AFAIK, but just in case merge both scenarios
+    messages_sent =
+      (Message.from_transaction_receipt(receipt) ++ [Message.from_transaction(transaction)])
+      |> Enum.reject(&is_nil/1)
 
     assigns = [
       transaction: transaction,


### PR DESCRIPTION
<img width="1339" alt="Screenshot 2023-09-13 at 21 29 44" src="https://github.com/lambdaclass/madara_explorer/assets/6981132/790aa0c9-df4e-46ef-b1d0-838f7f52d3a3">

- Saves block on DB on the case where it is requested through RPC as a fallback
- Adds L1->L2 message logs that are pertinent to L2
- Minor refactors
- Adds message table to make messages searchable
- Adds message view that shows latest 20 message logs
- Adds links on the `Message Logs` tabs 

Note that not all message logs are being stored on the DB, only those that can be derived from block (ie, all that are not registered on the L1)