### PR TITLE
fix: GH actions docker containers build form arm64

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM hexpm/elixir:1.14.5-erlang-25.3.2.6-alpine-3.18.2 AS builder
+FROM hexpm/elixir:1.14.5-erlang-24.3.4.13-debian-bullseye-20230612 AS builder
 
 ENV MIX_ENV=prod
 
@@ -14,7 +14,7 @@ RUN mix compile
 RUN mix release
 RUN mix phx.gen.release
 
-FROM elixir:1.14.5-otp-25
+FROM elixir:1.14.5-otp-24
 ENV MIX_ENV=prod
 
 WORKDIR /explorer

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,4 +23,4 @@ COPY --from=builder /explorer/_build/$MIX_ENV/rel/starknet_explorer .
 
 EXPOSE 4000
 
-CMD ["/explorer/bin/starknet_explorer", "start"]
+CMD ["sh", "-c", "/explorer/bin/starknet_explorer eval 'StarknetExplorer.Release.migrate' && /explorer/bin/starknet_explorer start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM hexpm/elixir:1.14.5-erlang-24.3.4.13-debian-bullseye-20230612 AS builder
+FROM hexpm/elixir:1.15.5-erlang-24.3.4.13-debian-bullseye-20230612 AS builder
 
 ENV MIX_ENV=prod
 
@@ -14,7 +14,7 @@ RUN mix compile
 RUN mix release
 RUN mix phx.gen.release
 
-FROM elixir:1.14.5-otp-24
+FROM elixir:1.15.5-otp-24
 ENV MIX_ENV=prod
 
 WORKDIR /explorer

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM elixir:1.14.5-otp-25 as builder
+FROM hexpm/elixir:1.14.5-erlang-25.3.2.6-alpine-3.18.2 AS builder
 
 ENV MIX_ENV=prod
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM hexpm/elixir:1.15.5-erlang-24.3.4.13-debian-bullseye-20230612 AS builder
+FROM hexpm/elixir:1.15.4-erlang-24.3.4.13-debian-bullseye-20230612 AS builder
 
 ENV MIX_ENV=prod
 
@@ -14,7 +14,7 @@ RUN mix compile
 RUN mix release
 RUN mix phx.gen.release
 
-FROM elixir:1.15.5-otp-24
+FROM elixir:1.15.4-otp-24
 ENV MIX_ENV=prod
 
 WORKDIR /explorer


### PR DESCRIPTION
## Problem
There is a segmentation fault problem while trying to build Elixir for arm64 using qemu

## Solution
Downgrade the Dockerfile to use OTP 24

## References
- https://elixirforum.com/t/phoenix-1-6-using-docker-containers-ends-with-segmentation-fault-error-139/42691/2
- https://gitlab.com/qemu-project/qemu/-/issues/1034
- https://github.com/processone/ejabberd/issues/3983

## Edit
Also changed the bootstrap command to run the db migrations on start