### PR TITLE
Fix transaction fetching on block view

### DIFF
--- a/lib/starknet_explorer_web/live/pages/block_detail.ex
+++ b/lib/starknet_explorer_web/live/pages/block_detail.ex
@@ -379,7 +379,7 @@ defmodule StarknetExplorerWeb.BlockDetailLive do
       <div>Type</div>
       <div>Version</div>
     </div>
-    <%= for _transaction = %StarknetExplorer.Transaction{hash: hash, type: type, version: version} <- @block.transactions do %>
+    <%= for _transaction = %{hash: hash, type: type, version: version} <- @block.transactions do %>
       <div class="grid-3 custom-list-item">
         <div>
           <div class="list-h">Hash</div>


### PR DESCRIPTION
Closes #156 
When fetching blocks for the first time, it was not cast to a `%StarknetExplorer.Transaction` which caused the pattern matching to fail