### PR TITLE
Revert dockerfile elixir to version 1.14.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM hexpm/elixir:1.15.4-erlang-24.3.4.13-debian-bullseye-20230612 AS builder
+FROM hexpm/elixir:1.14.5-erlang-24.3.4.13-debian-bullseye-20230612 AS builder
 
 ENV MIX_ENV=prod
 
@@ -14,7 +14,7 @@ RUN mix compile
 RUN mix release
 RUN mix phx.gen.release
 
-FROM elixir:1.15.4-otp-24
+FROM elixir:1.14.5-otp-24
 ENV MIX_ENV=prod
 
 WORKDIR /explorer


### PR DESCRIPTION
The fix on #142 only required to downgrade to OTP 24, not the elixir version upgrade