### PR TITLE
Add dummy newrelic env vars during build

### DIFF
--- a/ansible/playbooks/deployment.yaml
+++ b/ansible/playbooks/deployment.yaml
@@ -44,6 +44,8 @@
       RPC_API_HOST:
       TESTNET_RPC_API_HOST:
       TESTNET_2_RPC_API_HOST:
+      NEWRELIC_KEY:
+      NEWRELIC_APP_NAME:
       DATABASE_PATH: "{{ lookup('ansible.builtin.env', 'DATABASE_PATH') }}"
       SECRET_KEY_BASE: "{{ lookup('ansible.builtin.env', 'SECRET_KEY_BASE') }}"
       PORT: "4100"


### PR DESCRIPTION
Otherwise compilation fails:
** (RuntimeError) environment variable NEWRELIC_KEY is missing.