### PR TITLE
Detail tab fixes

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -158,10 +158,10 @@ input {
 
 /* Dropdown */
 main .options {
-  @apply bg-black/20 lg:bg-transparent lg:flex lg:flex-row mt-2 lg:mt-0 mb-10 lg:mb-0;
+  @apply bg-black/20 lg:bg-transparent lg:flex lg:flex-row mt-2 lg:mt-0 mb-10 lg:mb-0 lg:border-b border-b-gray-700;
 }
 main .option {
-  @apply border-b border-b-gray-800 py-3  px-3 transition-all duration-300;
+  @apply border-b border-b-transparent py-3 px-3 transition-all duration-300 -mb-px;
 }
 .option:hover {
   cursor: pointer;

--- a/lib/starknet_explorer_web/live/class_live.ex
+++ b/lib/starknet_explorer_web/live/class_live.ex
@@ -19,7 +19,7 @@ defmodule StarknetExplorerWeb.ClassDetailLive do
     </div>
     <div
       id="dropdown"
-      class="dropdown relative bg-[#232331] p-5 mb-5 rounded-md lg:hidden"
+      class="dropdown relative bg-[#232331] p-5 mb-2 rounded-md lg:hidden"
       phx-hook="Dropdown"
     >
       <span class="networkSelected capitalize"><%= assigns.view %></span>

--- a/lib/starknet_explorer_web/live/contract_live.ex
+++ b/lib/starknet_explorer_web/live/contract_live.ex
@@ -16,7 +16,7 @@ defmodule StarknetExplorerWeb.ContractDetailLive do
     </div>
     <div
       id="dropdown"
-      class="dropdown relative bg-[#232331] p-5 mb-5 rounded-md lg:hidden"
+      class="dropdown relative bg-[#232331] p-5 mb-2 rounded-md lg:hidden"
       phx-hook="Dropdown"
     >
       <span class="networkSelected capitalize"><%= assigns.view %></span>

--- a/lib/starknet_explorer_web/live/message_live.ex
+++ b/lib/starknet_explorer_web/live/message_live.ex
@@ -20,7 +20,7 @@ defmodule StarknetExplorerWeb.MessageDetailLive do
     ~H"""
     <div
       id="dropdown"
-      class="dropdown relative bg-[#232331] p-5 mb-5 rounded-md lg:hidden"
+      class="dropdown relative bg-[#232331] p-5 mb-2 rounded-md lg:hidden"
       phx-hook="Dropdown"
     >
       <span class="absolute inset-y-0 right-5 transform translate-1/2 flex items-center">

--- a/lib/starknet_explorer_web/live/pages/block_detail.ex
+++ b/lib/starknet_explorer_web/live/pages/block_detail.ex
@@ -75,7 +75,7 @@ defmodule StarknetExplorerWeb.BlockDetailLive do
     </div>
     <div
       id="dropdown"
-      class="dropdown relative bg-[#232331] p-5 mb-5 rounded-md lg:hidden"
+      class="dropdown relative bg-[#232331] p-5 mb-2 rounded-md lg:hidden"
       phx-hook="Dropdown"
     >
       <span class="networkSelected capitalize"><%= assigns.view %></span>
@@ -85,7 +85,7 @@ defmodule StarknetExplorerWeb.BlockDetailLive do
     </div>
     <div class="options hidden">
       <div
-        class={"option #{if assigns.view == "overview", do: "lg:!border-b-se-blue", else: "lg:border-b-transparent"}"}
+        class={"option #{if assigns.view == "overview", do: "lg:!border-b-se-blue text-white", else: "lg:border-b-transparent text-gray-400"}"}
         phx-click="select-view"
         ,
         phx-value-view="overview"
@@ -93,7 +93,7 @@ defmodule StarknetExplorerWeb.BlockDetailLive do
         Overview
       </div>
       <div
-        class={"option #{if assigns.view == "transactions", do: "lg:!border-b-se-blue", else: "lg:border-b-transparent"}"}
+        class={"option #{if assigns.view == "transactions", do: "lg:!border-b-se-blue text-white", else: "lg:border-b-transparent text-gray-400"}"}
         phx-click="select-view"
         ,
         phx-value-view="transactions"
@@ -101,7 +101,7 @@ defmodule StarknetExplorerWeb.BlockDetailLive do
         Transactions
       </div>
       <div
-        class={"option #{if assigns.view == "messages", do: "lg:!border-b-se-blue", else: "lg:border-b-transparent"}"}
+        class={"option #{if assigns.view == "messages", do: "lg:!border-b-se-blue text-white", else: "lg:border-b-transparent text-gray-400"}"}
         phx-click="select-view"
         ,
         phx-value-view="messages"
@@ -109,7 +109,7 @@ defmodule StarknetExplorerWeb.BlockDetailLive do
         Message Logs
       </div>
       <div
-        class={"option #{if assigns.view == "events", do: "lg:!border-b-se-blue", else: "lg:border-b-transparent"}"}
+        class={"option #{if assigns.view == "events", do: "lg:!border-b-se-blue text-white", else: "lg:border-b-transparent text-gray-400"}"}
         phx-click="select-view"
         ,
         phx-value-view="events"
@@ -294,7 +294,7 @@ defmodule StarknetExplorerWeb.BlockDetailLive do
 
   def render_info(assigns = %{block: _, view: "transactions"}) do
     ~H"""
-    <div class="grid-3 table-th !pt-7 border-t border-gray-700">
+    <div class="grid-3 table-th !pt-7">
       <div>Hash</div>
       <div>Type</div>
       <div>Version</div>
@@ -527,7 +527,7 @@ defmodule StarknetExplorerWeb.BlockDetailLive do
         </div>
       </div>
     <% end %>
-    <div class="grid-4 custom-list-item">
+    <div class="grid-4 custom-list-item lg:border-transparent">
       <div class="block-label">Block Hash</div>
       <div
         class="copy-container col-span-3 text-hover-blue"
@@ -662,7 +662,7 @@ defmodule StarknetExplorerWeb.BlockDetailLive do
 
   def render_info(assigns = %{block: _block, view: "events"}) do
     ~H"""
-    <div class="table-th !pt-7 border-t border-gray-700 grid-6">
+    <div class="table-th !pt-7 grid-6">
       <div>Identifier</div>
       <div>Block Number</div>
       <div>Transaction Hash</div>

--- a/lib/starknet_explorer_web/live/transaction_live.ex
+++ b/lib/starknet_explorer_web/live/transaction_live.ex
@@ -34,7 +34,7 @@ defmodule StarknetExplorerWeb.TransactionLive do
     </div>
     <div
       id="dropdown"
-      class="dropdown relative bg-[#232331] p-5 mb-5 rounded-md lg:hidden"
+      class="dropdown relative bg-[#232331] p-5 mb-2 rounded-md lg:hidden"
       phx-hook="Dropdown"
     >
       <span class="networkSelected capitalize"><%= assigns.transaction_view %></span>
@@ -44,7 +44,7 @@ defmodule StarknetExplorerWeb.TransactionLive do
     </div>
     <div class="options hidden">
       <div
-        class={"option #{if assigns.transaction_view == "overview", do: "lg:!border-b-se-blue", else: "lg:border-b-transparent"}"}
+        class={"option #{if assigns.transaction_view == "overview", do: "lg:!border-b-se-blue text-white", else: "text-gray-400 lg:border-b-transparent"}"}
         phx-click="select-view"
         ,
         phx-value-view="overview"
@@ -52,7 +52,7 @@ defmodule StarknetExplorerWeb.TransactionLive do
         Overview
       </div>
       <div
-        class={"option #{if assigns.transaction_view == "events", do: "lg:!border-b-se-blue", else: "lg:border-b-transparent"}"}
+        class={"option #{if assigns.transaction_view == "events", do: "lg:!border-b-se-blue text-white", else: "text-gray-400 lg:border-b-transparent"}"}
         phx-click="select-view"
         ,
         phx-value-view="events"
@@ -60,7 +60,7 @@ defmodule StarknetExplorerWeb.TransactionLive do
         Events
       </div>
       <div
-        class={"option #{if assigns.transaction_view == "message_logs", do: "lg:!border-b-se-blue", else: "lg:border-b-transparent"}"}
+        class={"option #{if assigns.transaction_view == "message_logs", do: "lg:!border-b-se-blue text-white", else: "text-gray-400 lg:border-b-transparent"}"}
         phx-click="select-view"
         ,
         phx-value-view="message_logs"
@@ -69,7 +69,7 @@ defmodule StarknetExplorerWeb.TransactionLive do
       </div>
       <%= if @internal_calls != nil do %>
         <div
-          class={"option #{if assigns.transaction_view == "internal_calls", do: "lg:!border-b-se-blue", else: "lg:border-b-transparent"}"}
+          class={"option #{if assigns.transaction_view == "internal_calls", do: "lg:!border-b-se-blue text-white", else: "text-gray-400 lg:border-b-transparent"}"}
           phx-click="select-view"
           ,
           phx-value-view="internal_calls"
@@ -106,7 +106,7 @@ defmodule StarknetExplorerWeb.TransactionLive do
 
   def render_info(%{transaction_view: "events"} = assigns) do
     ~H"""
-    <div class="table-th !pt-7 border-t border-gray-700 grid-5">
+    <div class="table-th !pt-7 grid-5">
       <div>Identifier</div>
       <div>Block Number</div>
       <div>Name</div>
@@ -421,7 +421,7 @@ defmodule StarknetExplorerWeb.TransactionLive do
   # Execution resources
   def render_info(%{transaction_view: "overview"} = assigns) do
     ~H"""
-    <div class="grid-4 custom-list-item">
+    <div class="grid-4 custom-list-item lg:border-transparent">
       <div class="block-label">Transaction Hash</div>
       <div class="col-span-3 break-all">
         <div class="copy-container" id={"tsx-overview-hash-#{@transaction.hash}"} phx-hook="Copy">
@@ -648,7 +648,7 @@ defmodule StarknetExplorerWeb.TransactionLive do
         <% end %>
       </div>
     </div>
-    <div class="pt-3 mb-3 border-t border-t-gray-700">
+    <div class="pt-3 mb-3">
       <div class="mb-5 text-gray-500 md:text-white !flex-row gap-5">
         <span>Execution Resources</span><span class="gray-label text-sm">Mocked</span>
       </div>


### PR DESCRIPTION
I noticed some styles in detail tabs were broken so I fixed them:
Before:
<img width="1319" alt="Captura de pantalla 2023-09-25 a las 16 51 49 p  m" src="https://github.com/lambdaclass/madara_explorer/assets/82987608/a1fd68c9-f19a-4320-ac4a-8d2b80ea7ee3">

After:
<img width="1314" alt="Captura de pantalla 2023-09-25 a las 16 52 14 p  m" src="https://github.com/lambdaclass/madara_explorer/assets/82987608/7731e1e2-ee6a-4e81-8e7a-af976b249cfc">
