### PR TITLE
Split entities count by network

### DIFF
--- a/lib/starknet_explorer/data.ex
+++ b/lib/starknet_explorer/data.ex
@@ -237,10 +237,10 @@ defmodule StarknetExplorer.Data do
     []
   end
 
-  def get_entity_count() do
+  def get_entity_count(network) do
     Map.new()
-    |> Map.put(:message_count, Message.get_total_count())
-    |> Map.put(:events_count, Events.get_total_count())
-    |> Map.put(:transaction_count, Transaction.get_total_count())
+    |> Map.put(:message_count, Message.get_total_count(network))
+    |> Map.put(:events_count, Events.get_total_count(network))
+    |> Map.put(:transaction_count, Transaction.get_total_count(network))
   end
 end

--- a/lib/starknet_explorer/events.ex
+++ b/lib/starknet_explorer/events.ex
@@ -153,8 +153,9 @@ defmodule StarknetExplorer.Events do
     )
   end
 
-  def get_total_count() do
-    StarknetExplorer.Events |> Repo.aggregate(:count, :id)
+  def get_total_count(network) do
+    from(event in __MODULE__, where: event.network == ^network, select: count())
+    |> Repo.one()
   end
 
   def fetch_from_rpc(block_hash, network) do

--- a/lib/starknet_explorer/message.ex
+++ b/lib/starknet_explorer/message.ex
@@ -81,8 +81,9 @@ defmodule StarknetExplorer.Message do
     Repo.all(query)
   end
 
-  def get_total_count() do
-    StarknetExplorer.Message |> Repo.aggregate(:count, :to_address)
+  def get_total_count(network) do
+    from(msg in __MODULE__, where: msg.network == ^network, select: count())
+    |> Repo.one()
   end
 
   def insert_from_transaction(transaction, timestamp, network) do

--- a/lib/starknet_explorer/transaction.ex
+++ b/lib/starknet_explorer/transaction.ex
@@ -190,7 +190,8 @@ defmodule StarknetExplorer.Transaction do
     |> validate_required(@l1_handler_tx_fields)
   end
 
-  def get_total_count() do
-    StarknetExplorer.Transaction |> Repo.aggregate(:count, :hash)
+  def get_total_count(network) do
+    from(tx in __MODULE__, where: tx.network == ^network, select: count())
+    |> Repo.one()
   end
 end

--- a/lib/starknet_explorer_web/live/pages/home/index.ex
+++ b/lib/starknet_explorer_web/live/pages/home/index.ex
@@ -278,7 +278,7 @@ defmodule StarknetExplorerWeb.HomeLive.Index do
 
         # get entities count and format for display
         entities_count =
-          StarknetExplorer.Data.get_entity_count()
+          StarknetExplorer.Data.get_entity_count(socket.assigns.network)
           |> Enum.map(fn {entity, count} ->
             {entity, StarknetExplorer.Utils.format_number_for_display(count)}
           end)


### PR DESCRIPTION
On the home page, the `message`, `event`, and `transaction` counts were not being calculated per network, but rather as a total. This PR fixes it